### PR TITLE
Add timeout to html gen child process

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   },
   "rules": {
     "arrow-parens": [2, "always"],

--- a/config.js
+++ b/config.js
@@ -32,7 +32,8 @@ const hideFormfieldsPath = process.env.HIDE_FORMFIELDS;
 // 7 seconds seems like a sensible default I guess? We don't want PDFs that don't need postscript
 // optimization to be optimized in this way, but we also want to stay under common reverse proxy
 // timeout configurations so we don't receive a 504
-const htmlGenerationTimeout = process.env.TIMEOUT ? process.env.TIMEOUT : 7000;
+const htmlGenerationTimeout = process.env.HTML_GENERATION_TIMEOUT
+  ? process.env.HTML_GENERATION_TIMEOUT : 7000;
 
 module.exports = {
   port,

--- a/config.js
+++ b/config.js
@@ -33,8 +33,8 @@ const hideFormfieldsPath = process.env.HIDE_FORMFIELDS;
 // that don't need postscript optimization to be optimized in this way, but we also want to
 // stay under common reverse proxy timeout configurations so we don't receive a 504
 const htmlGenerationTimeoutConfig = {
-  timeout: process.env.HTML_GENERATION_TIMEOUT ? process.env.HTML_GENERATION_TIMEOUT : 7000,
-  backoff: process.env.HTML_GENERATION_BACKOFF ? process.env.HTML_GENERATION_BACKOFF : 23000
+  timeout: process.env.HTML_GENERATION_TIMEOUT ?? 7000,
+  backoff: process.env.HTML_GENERATION_BACKOFF ?? 23000
 };
 
 module.exports = {

--- a/config.js
+++ b/config.js
@@ -29,11 +29,13 @@ if (!extractFormfieldsPath) {
 
 const hideFormfieldsPath = process.env.HIDE_FORMFIELDS;
 
-// 7 seconds seems like a sensible default I guess? We don't want PDFs that don't need postscript
-// optimization to be optimized in this way, but we also want to stay under common reverse proxy
-// timeout configurations so we don't receive a 504
-const htmlGenerationTimeout = process.env.HTML_GENERATION_TIMEOUT
-  ? process.env.HTML_GENERATION_TIMEOUT : 7000;
+// 7 seconds (and then 30 seconds) seems like a sensible default I guess? We don't want PDFs
+// that don't need postscript optimization to be optimized in this way, but we also want to
+// stay under common reverse proxy timeout configurations so we don't receive a 504
+const htmlGenerationTimeoutConfig = {
+  timeout: process.env.HTML_GENERATION_TIMEOUT ? process.env.HTML_GENERATION_TIMEOUT : 7000,
+  backoff: process.env.HTML_GENERATION_BACKOFF ? process.env.HTML_GENERATION_BACKOFF : 23000
+};
 
 module.exports = {
   port,
@@ -41,5 +43,5 @@ module.exports = {
   pdf2htmlexPath,
   psToPdfPath,
   hideFormfieldsPath,
-  htmlGenerationTimeout
+  htmlGenerationTimeoutConfig
 };

--- a/config.js
+++ b/config.js
@@ -29,7 +29,10 @@ if (!extractFormfieldsPath) {
 
 const hideFormfieldsPath = process.env.HIDE_FORMFIELDS;
 
-const htmlGenerationTimeout = Number(process.env.TIMEOUT);
+// 7 seconds seems like a sensible default I guess? We don't want PDFs that don't need postscript
+// optimization to be optimized in this way, but we also want to stay under common reverse proxy
+// timeout configurations so we don't receive a 504
+const htmlGenerationTimeout = process.env.TIMEOUT ? process.env.TIMEOUT : 7000;
 
 module.exports = {
   port,

--- a/config.js
+++ b/config.js
@@ -29,10 +29,13 @@ if (!extractFormfieldsPath) {
 
 const hideFormfieldsPath = process.env.HIDE_FORMFIELDS;
 
+const htmlGenerationTimeout = Number(process.env.TIMEOUT);
+
 module.exports = {
   port,
   extractFormfieldsPath,
   pdf2htmlexPath,
   psToPdfPath,
-  hideFormfieldsPath
+  hideFormfieldsPath,
+  htmlGenerationTimeout
 };

--- a/src/pdf/middleware/convert-to-html.js
+++ b/src/pdf/middleware/convert-to-html.js
@@ -5,11 +5,14 @@ const {v4: uuid} = require('uuid');
 const tmpdir = require('os').tmpdir();
 
 const {generateHtml} = require('../services/convert-to-html');
+const {htmlGenerationTimeoutConfig} = require('../../../config');
 
 const convertToHtml = async (req, res, next) => {
   const outputFileName = `${uuid()}.html`;
   const outputPath = path.join(tmpdir, `${outputFileName}`);
   req.cleanup.push(outputPath);
+  const {timeout, backoff} = htmlGenerationTimeoutConfig;
+  const calculatedTimeout = req.optimizedPdf ? timeout + backoff : timeout;
   try {
     await generateHtml(
       req.filePath,
@@ -18,7 +21,8 @@ const convertToHtml = async (req, res, next) => {
         zoom: req.query.zoom || 1.78,
         dpi: req.query.dpi || 144
       },
-      ['--dest-dir', tmpdir]
+      ['--dest-dir', tmpdir],
+      calculatedTimeout
     );
   } catch (err) {
     return req.optimizedPdf

--- a/src/pdf/services/convert-to-html/generate-html.js
+++ b/src/pdf/services/convert-to-html/generate-html.js
@@ -1,9 +1,8 @@
 'use strict';
 
-/* eslint-disable no-console */
+const {spawn} = require('child_process');
 
-const {pdf2htmlexPath} = require('../../../../config');
-const {exec} = require('../../utils');
+const {pdf2htmlexPath, htmlGenerationTimeout} = require('../../../../config');
 
 const generateHtml = async (filePath, toFile, params, commands) => {
   // try {
@@ -17,26 +16,26 @@ const generateHtml = async (filePath, toFile, params, commands) => {
     `${__dirname}/data-dir`,
     '--zoom',
     zoom,
-    '--dpi',
-    dpi,
-    '--quiet',
-    '1',
+    // '--dpi',
+    // dpi,
+    // '--quiet',
+    // '1',
     filePath,
     toFile
   ]);
-  // return new Promise((resolve, reject) => {
-  //   spawn(pdf2htmlexPath, args)
-  //     .on('close', (code) => {
-  //       if (code === 0) {
-  //         resolve(toFile);
-  //       } else {
-  //         reject(new Error('ERROR: Converting pdf to html'));
-  //       }
-  //     }).on('error', (err) => {
-  //       reject(err.message || err, null);
-  //     });
-  // });
-  await exec(`${pdf2htmlexPath} ${args.join(' ')}`);
+  return new Promise((resolve, reject) => {
+    spawn(pdf2htmlexPath, args, {timeout: htmlGenerationTimeout})
+      .on('close', (code) => {
+        if (code === 0) {
+          resolve(toFile);
+        } else {
+          reject(new Error('ERROR: Converting pdf to html'));
+        }
+      })
+      .on('error', (err) => {
+        reject(err.message || err, null);
+      });
+  });
 };
 
 module.exports = generateHtml;

--- a/src/pdf/services/convert-to-html/generate-html.js
+++ b/src/pdf/services/convert-to-html/generate-html.js
@@ -16,10 +16,10 @@ const generateHtml = async (filePath, toFile, params, commands) => {
     `${__dirname}/data-dir`,
     '--zoom',
     zoom,
-    // '--dpi',
-    // dpi,
-    // '--quiet',
-    // '1',
+    '--dpi',
+    dpi,
+    '--quiet',
+    '1',
     filePath,
     toFile
   ]);

--- a/src/pdf/services/convert-to-html/generate-html.js
+++ b/src/pdf/services/convert-to-html/generate-html.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const {spawn} = require('child_process');
-
 const {pdf2htmlexPath, htmlGenerationTimeout} = require('../../../../config');
+const {exec} = require('../../utils');
 
 const generateHtml = async (filePath, toFile, params, commands) => {
   // try {
@@ -23,19 +22,7 @@ const generateHtml = async (filePath, toFile, params, commands) => {
     filePath,
     toFile
   ]);
-  return new Promise((resolve, reject) => {
-    spawn(pdf2htmlexPath, args, {timeout: htmlGenerationTimeout})
-      .on('close', (code) => {
-        if (code === 0) {
-          resolve(toFile);
-        } else {
-          reject(new Error('ERROR: Converting pdf to html'));
-        }
-      })
-      .on('error', (err) => {
-        reject(err.message || err, null);
-      });
-  });
+  await exec(`${pdf2htmlexPath} ${args.join(' ')}`, {timeout: htmlGenerationTimeout});
 };
 
 module.exports = generateHtml;

--- a/src/pdf/services/convert-to-html/generate-html.js
+++ b/src/pdf/services/convert-to-html/generate-html.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const {pdf2htmlexPath, htmlGenerationTimeout} = require('../../../../config');
+const {pdf2htmlexPath} = require('../../../../config');
 const {exec} = require('../../utils');
 
-const generateHtml = async (filePath, toFile, params, commands) => {
+const generateHtml = async (filePath, toFile, params, commands, timeout) => {
   // try {
   const {zoom, dpi} = params;
   const args = commands.concat([
@@ -22,7 +22,7 @@ const generateHtml = async (filePath, toFile, params, commands) => {
     filePath,
     toFile
   ]);
-  await exec(`${pdf2htmlexPath} ${args.join(' ')}`, {timeout: htmlGenerationTimeout});
+  await exec(`${pdf2htmlexPath} ${args.join(' ')}`, {timeout});
 };
 
 module.exports = generateHtml;


### PR DESCRIPTION
Previously, files such as [this seemingly simple resume](https://github.com/coolwanglu/pdf2htmlEX/files/2145520/Caroline_Njuguna__Cover_Letter_-_ILRI.pdf) will cause `pdf2htmlex` to hang and sometimes curiously exit with a Code 0 (this is an [open issue](https://github.com/coolwanglu/pdf2htmlEX/issues/776) in `pdf2htmlex`). Debugging this particular PDF pointed to a problem with one of the PDF file's unused fonts versus `pdf2htmlex`'s cobbled-together `fontforge` header files. After optimization via `pdftops`, however, this problem goes away. Rather than try and debug an ancient version of `fontforge`, we should allow for a sensible timeout value that will kill the initial HTML generation child process (rather than only wait for an error) and attempt to optimize.