### PR TITLE
FIO 6640: Changes to Dockerfile to not pull from edge repositories

### DIFF
--- a/cpp/extract-formfields/CMakeLists.txt
+++ b/cpp/extract-formfields/CMakeLists.txt
@@ -17,7 +17,7 @@ set(LIB_DIR /lib/x86_64-linux-gnu)
 set(INCLUDE_POPPLER /usr/include/poppler/cpp)
 set(INCLUDE_POPPLER_QT /usr/include/poppler/qt5)
 set(INCLUDE_QT /usr/include/qt5)
-set(INCLUDE_QT_CORE /usr/include/qt5/QtCore)
+set(INCLUDE_QT_CORE /usr/include/QtCore)
 
 add_executable(extract-formfields main.cpp version.h src/document.cpp src/page.cpp src/field.cpp src/fields/button-field.cpp src/fields/text-field.cpp src/fields/choice-field.cpp)
 

--- a/cpp/hide-formfields/CMakeLists.txt
+++ b/cpp/hide-formfields/CMakeLists.txt
@@ -17,7 +17,7 @@ set(LIB_DIR /lib/x86_64-linux-gnu)
 set(INCLUDE_POPPLER /usr/include/poppler/cpp)
 set(INCLUDE_POPPLER_QT /usr/include/poppler/qt5)
 set(INCLUDE_QT /usr/include/qt5)
-set(INCLUDE_QT_CORE /usr/include/qt5/QtCore)
+set(INCLUDE_QT_CORE /usr/include/QtCore)
 
 add_executable(hide-formfields main.cpp)
 

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -34,6 +34,8 @@ RUN apk update \
     && rm -rf /var/lib/apt/lists/* \
     && rm /var/cache/apk/*
 
+RUN npm update -g npm
+
 # Install fonts
 RUN apk add --no-cache msttcorefonts-installer fontconfig \
     && update-ms-fonts \

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.12.12
+FROM node:lts-alpine:3.12
 LABEL maintainer="Form.io <support@form.io>"
 
-# Installing dependencies
+# Install dependencies
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache \
@@ -13,38 +13,36 @@ RUN apk update \
     dumb-init \
     git \
     wget \
-    && sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories \
-    && apk add --upgrade \
-    nodejs npm yarn nghttp2 nghttp2-libs libxslt libass cairo libx11 ghostscript poppler-data poppler-utils gettext\
+    yarn \
+    nghttp2 \
+    nghttp2-libs \
+    libxslt \
+    libass \
+    cairo \
+    libx11 \
+    ghostscript \
+    poppler-data \
+    poppler-utils \
+    gettext \
+    build-base \
+    poppler \
+    qt5-qtbase \
+    qt5-qtbase-dev \
+    poppler-qt5 \
+    poppler-dev \
+    poppler-qt5-dev \
     && rm -rf /var/lib/apt/lists/* \
     && rm /var/cache/apk/*
 
-# Fonts
+# Install fonts
 RUN apk add --no-cache msttcorefonts-installer fontconfig \
     && update-ms-fonts \
-# Google fonts
     && wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz \
     && tar -xf gf.tar.gz \
     && mkdir -p /usr/share/fonts/truetype/google-fonts \
     && find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 \
     && rm -f gf.tar.gz \
     && rm -rf /fonts-main
-
-RUN apk add --upgrade nghttp2 nghttp2-libs libxslt libass cairo libx11 chromium ghostscript poppler-data poppler-utils gettext \
-        && rm -rf /var/lib/apt/lists/* \
-        && rm /var/cache/apk/*
-
-
-RUN apk update
-
-RUN apk add --update build-base
-RUN apk add --update poppler
-RUN apk add --update qt5-qtbase
-RUN apk add --update qt5-qtbase-dev
-RUN apk add --update poppler-qt5
-RUN apk add --update poppler-dev
-RUN apk add --update poppler-qt5-dev
-# End installing dependencies
 
 ENV APP_ROOT=/usr/src/pdf-libs
 WORKDIR $APP_ROOT

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine:3.12
+FROM node:lts-alpine3.12
 LABEL maintainer="Form.io <support@form.io>"
 
 # Install dependencies


### PR DESCRIPTION
Previously, the pdf-libs Dockerfile was running `sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories`  which replaces the main Alpine Package Keeper repositories with edge/development repos. This appears to be causing the libc musl to be patched, so my solution is to 

* ensure we're running the LTS version of Node that's associated with Alpine 3.12, namely 16.x;
* combine all of the dependencies into one build layer (which will decrease the size of the Docker image dramatically); and
* update the CMake files of our C++ libraries to reflect the location of linked libraries on non-edge dependencies.
