### PR TITLE
FIO-6640: Move to Ubuntu to fix dependency problems between chromium and pdf2htmlEX

### DIFF
--- a/cpp/extract-formfields/CMakeLists.txt
+++ b/cpp/extract-formfields/CMakeLists.txt
@@ -11,13 +11,14 @@ find_library(qt Qt5Core)
 message("${qt}")
 message("${poppler}")
 message("${poppler-qt}")
+add_definitions(-fPIC)
 
 set(LIB_DIR /lib/x86_64-linux-gnu)
 
 set(INCLUDE_POPPLER /usr/include/poppler/cpp)
 set(INCLUDE_POPPLER_QT /usr/include/poppler/qt5)
-set(INCLUDE_QT /usr/include/qt5)
-set(INCLUDE_QT_CORE /usr/include/QtCore)
+set(INCLUDE_QT /usr/include/x86_64-linux-gnu/qt5)
+set(INCLUDE_QT_CORE /usr/include/x86_64-linux-gnu/qt5/QtCore)
 
 add_executable(extract-formfields main.cpp version.h src/document.cpp src/page.cpp src/field.cpp src/fields/button-field.cpp src/fields/text-field.cpp src/fields/choice-field.cpp)
 

--- a/cpp/extract-formfields/build.sh
+++ b/cpp/extract-formfields/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+set -ev
 mkdir bin
 mkdir build
 cd build

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -16,27 +16,30 @@ RUN apt-get update && \
     g++ \
     cmake \
     make \
+    openssh-client \
+    git \
+    libcap2-bin \
     libpoppler-dev \
     libpoppler-qt5-dev \
     qtbase5-dev \
     ghostscript && \
+    # pdf2htmlEX
+    wget "$PDF2HTMLEX_URL" && \
+    apt-get install -y --no-install-recommends ./$PDF2HTMLEX && \
+    # Disable EULA agreement for msttcorefonts
+    echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections && \
+    # Fonts
+    apt-get install -y ttf-mscorefonts-installer && \
+    wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz && \
+    tar -xf gf.tar.gz && \
+    mkdir -p /usr/share/fonts/truetype/google-fonts && \
+    find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 && \
     # Chromium
     wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
     apt-get update && \
     apt-get install google-chrome-stable -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
-    # pdf2htmlEX
-    wget "$PDF2HTMLEX_URL" && \
-    apt install -y --no-install-recommends ./$PDF2HTMLEX && \
-    # Disable EULA agreement for msttcorefonts
-    # echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections && \
-    # Fonts
-    # apt-get install -y ttf-mscorefonts-installer && \
-    # wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz && \
-    # tar -xf gf.tar.gz && \
-    # mkdir -p /usr/share/fonts/truetype/google-fonts && \
-    # find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 && \
     # Node.js and Yarn v1.x
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
     apt-get install -y nodejs && \

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,86 +1,69 @@
 FROM ubuntu:22.04
 LABEL maintainer="Form.io <support@form.io>"
 
-# Install dependencies
-RUN apt-get update \
-    && apt-get install \
-    cmake \
-    ttf-freefont \
-    gnu-libiconv-dev \
-    libvpx \
-    dumb-init \
-    git \
+# Set initial environment variables
+ENV PDF2HTMLEX_URL=https://github.com/pdf2htmlEX/pdf2htmlEX/releases/download/v0.18.8.rc1/pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
+    PDF2HTMLEX=pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
+    DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies, fonts, chromium, and pdf2htmlEX
+RUN apt-get update && \
+    # Dependencies
+    apt-get install -y \
+    gnupg \
     wget \
-    nghttp2 \
-    nghttp2-libs \
-    libxslt \
-    libass \
-    cairo \
-    libcairo-dev \
-    libpng-dev \
-    libjpeg-dev \
-    libxml2-dev \
-    libx11 \
-    ghostscript \
-    poppler-data \
-    poppler-utils \
-    gettext \
-    build-base \
-    poppler \
-    qt5-qtbase \
-    qt5-qtbase-dev \
-    poppler-qt5 \
-    poppler-dev \
-    poppler-qt5-dev \
-    yarn \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm /var/cache/apk/*
-
-RUN npm update -g npm
-
-# Install fonts
-RUN apk add --no-cache msttcorefonts-installer fontconfig \
-    && update-ms-fonts \
-    && wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz \
-    && tar -xf gf.tar.gz \
-    && mkdir -p /usr/share/fonts/truetype/google-fonts \
-    && find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 \
-    && rm -f gf.tar.gz \
-    && rm -rf /fonts-main
+    curl \
+    g++ \
+    cmake \
+    make \
+    libpoppler-dev \
+    libpoppler-qt5-dev \
+    qtbase5-dev \
+    ghostscript && \
+    # Chromium
+    wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
+    apt-get update && \
+    apt-get install google-chrome-stable -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    # pdf2htmlEX
+    wget "$PDF2HTMLEX_URL" && \
+    apt install -y --no-install-recommends ./$PDF2HTMLEX && \
+    # Disable EULA agreement for msttcorefonts
+    # echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections && \
+    # Fonts
+    # apt-get install -y ttf-mscorefonts-installer && \
+    # wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz && \
+    # tar -xf gf.tar.gz && \
+    # mkdir -p /usr/share/fonts/truetype/google-fonts && \
+    # find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 && \
+    # Node.js and Yarn v1.x
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
+    apt-get install -y nodejs && \
+    npm install -g yarn && \
+    # Cleanup
+    apt-get clean && \
+    rm -f gf.tar.gz && \
+    rm -rf /fonts-main
 
 ENV APP_ROOT=/usr/src/pdf-libs
 WORKDIR $APP_ROOT
 
-# Building C++ tools
+# Build extract-formfields tool
 COPY cpp ./cpp
-## Building extract-formfields tool
 ARG EXTRACT_FORMFIELDS_ROOT=$APP_ROOT/cpp/extract-formfields
 WORKDIR $EXTRACT_FORMFIELDS_ROOT
 RUN ${EXTRACT_FORMFIELDS_ROOT}/build.sh
-ENV EXTRACT_FORMFIELDS=$EXTRACT_FORMFIELDS_ROOT/bin/extract-formfields
 
-## Building hide-formfields tool
-ARG HIDE_FORMFIELDS_ROOT=$APP_ROOT/cpp/hide-formfields
-WORKDIR $HIDE_FORMFIELDS_ROOT
-RUN ${HIDE_FORMFIELDS_ROOT}/build.sh
-ENV HIDE_FORMFIELDS=$HIDE_FORMFIELDS_ROOT/bin/hide-formfields
-# End building C++ tools
-
-# Installing third-party tools
-## Installing pdf2htmlEX
-WORKDIR /usr/src/pdf-libs
-RUN mkdir pdf2HtmlEx
-RUN wget https://github.com/pdf2htmlEX/pdf2htmlEX/releases/download/v0.18.8.rc1/pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
-    && apt -y upgrade && \
-    && apt -y --no-install-recommends install ./pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
-ENV PDF2HTMLEX_PATH="/usr/local/bin/pdf2htmlEX" \
+# Set runtime environment variables
+ENV EXTRACT_FORMFIELDS=$EXTRACT_FORMFIELDS_ROOT/bin/extract-formfields \
+    PDF2HTMLEX_PATH="/usr/local/bin/pdf2htmlEX" \
     PSTOPDF_PATH="/usr/bin/ps2pdf"
-# End installing third-party tools
 
 # Installing node.js packages
 COPY package.json ./
 COPY yarn.lock ./
-RUN yarn install --prod
+RUN yarn install --production
 
 # Adding sources
 COPY src ./src

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,11 +1,9 @@
-FROM node:lts-alpine3.12
+FROM ubuntu:22.04
 LABEL maintainer="Form.io <support@form.io>"
 
 # Install dependencies
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache \
-    apk-tools \
+RUN apt-get update \
+    && apt-get install \
     cmake \
     ttf-freefont \
     gnu-libiconv-dev \
@@ -13,12 +11,15 @@ RUN apk update \
     dumb-init \
     git \
     wget \
-    yarn \
     nghttp2 \
     nghttp2-libs \
     libxslt \
     libass \
     cairo \
+    libcairo-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libxml2-dev \
     libx11 \
     ghostscript \
     poppler-data \
@@ -31,42 +32,7 @@ RUN apk update \
     poppler-qt5 \
     poppler-dev \
     poppler-qt5-dev \
-    gconf-service \
-    libasound2 \
-    libatk1.0-0 \
-    libc6 \
-    libcairo2 \
-    libcups2 \
-    libdbus-1-3 \
-    libexpat1 \
-    libfontconfig1 \
-    libgcc1 \
-    libgconf-2-4 \
-    libgdk-pixbuf2.0-0 \
-    libglib2.0-0 \
-    libgtk-3-0 \
-    libnspr4 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libstdc++6 \
-    libx11-6 \
-    libx11-xcb1 \
-    libxcb1 \
-    libxcomposite1 \
-    libxcursor1 \
-    libxdamage1 \
-    libxext6 \
-    libxfixes3 \
-    libxi6 \
-    libxrandr2 \
-    libxrender1 \
-    libxss1 \
-    libxtst6 \
-    ca-certificates \
-    fonts-liberation \
-    libnss3 \
-    lsb-release \
-    xdg-utils \
+    yarn \
     && rm -rf /var/lib/apt/lists/* \
     && rm /var/cache/apk/*
 
@@ -104,9 +70,9 @@ ENV HIDE_FORMFIELDS=$HIDE_FORMFIELDS_ROOT/bin/hide-formfields
 ## Installing pdf2htmlEX
 WORKDIR /usr/src/pdf-libs
 RUN mkdir pdf2HtmlEx
-RUN wget https://github.com/pdf2htmlEX/pdf2htmlEX/releases/download/v0.18.8.rc1/pdf2htmlEX-0.18.8.rc1-master-20200630-alpine-3.12.0-x86_64.tar.gz -O pdf2HtmlEx.tar.gz \
-    && tar -xvf pdf2HtmlEx.tar.gz  -C / \
-    && rm -f pdf2HtmlEx.tar.gz
+RUN wget https://github.com/pdf2htmlEX/pdf2htmlEX/releases/download/v0.18.8.rc1/pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
+    && apt -y upgrade && \
+    && apt -y --no-install-recommends install ./pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
 ENV PDF2HTMLEX_PATH="/usr/local/bin/pdf2htmlEX" \
     PSTOPDF_PATH="/usr/bin/ps2pdf"
 # End installing third-party tools

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15
 MAINTAINER  Form.io <support@form.io>
 
 # Installing dependencies

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -63,6 +63,8 @@ ENV EXTRACT_FORMFIELDS=$EXTRACT_FORMFIELDS_ROOT/bin/extract-formfields \
     PDF2HTMLEX_PATH="/usr/local/bin/pdf2htmlEX" \
     PSTOPDF_PATH="/usr/bin/ps2pdf"
 
+WORKDIR $APP_ROOT
+
 # Installing node.js packages
 COPY package.json ./
 COPY yarn.lock ./


### PR DESCRIPTION
Previously, pdf2htmlEX would not function correctly in Docker containers running Alpine Linux >= 3.13.0. By moving to a Ubuntu distribution, we are able to

* trim ~ 1GB from the final size of the pdf-server docker image
* run pdf2htmlEX with predictable results (i.e. no mystery runtime errors)
* in pdf-server, run puppeteer 19.8.0 with a modern version of google-chrome (**NOT chromium in this case** because [you can't install snap packages in Docker containers](https://forum.snapcraft.io/t/install-snap-in-docker/20740) and [chromium is only available as a snap package](https://askubuntu.com/questions/1204571/how-to-install-chromium-without-snap#comment2244076_1300155)