### PR TITLE
Added poppler-utils

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
     libpoppler-dev \
     libpoppler-qt5-dev \
     qtbase5-dev \
+    poppler-utils \
     ghostscript && \
     # pdf2htmlEX
     wget "$PDF2HTMLEX_URL" && \


### PR DESCRIPTION
## Link to Jira Ticket (if applicable)

https://formio.atlassian.net/browse/FIO-7174

## Description

**What changed?**

The root of that issue is the migrating from alpine to debian for pdf-libs. Debian poppler package does not include pdfuntie by default. The attached submission is unwinded by formio/core util and pdf-server was crashing with ENOENT when trying to unite pdfs. So, for debian additional package named poppler-utils needs to be installed.

## Dependencies

none

## How has this PR been tested?

Checked pdf-libs image to ensure it contains pdfunite

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
