### PR TITLE
Task/update nodesource script

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="Form.io <support@form.io>"
 # Set initial environment variables
 ENV PDF2HTMLEX_URL=https://github.com/pdf2htmlEX/pdf2htmlEX/releases/download/v0.18.8.rc1/pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
     PDF2HTMLEX=pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
-    DEBIAN_FRONTEND=noninteractive
+    DEBIAN_FRONTEND=noninteractive \
+    NODE_MAJOR=18
 
 # Install dependencies, fonts, chromium, and pdf2htmlEX
 RUN apt-get update && \
@@ -13,6 +14,7 @@ RUN apt-get update && \
     gnupg \
     wget \
     curl \
+    ca-certificates \
     g++ \
     cmake \
     make \
@@ -38,10 +40,13 @@ RUN apt-get update && \
     wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
     apt-get update && \
-    apt-get install google-chrome-stable -y --no-install-recommends && \
+    apt-get install google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     # Node.js and Yarn v1.x
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
     apt-get install -y nodejs && \
     npm install -g yarn && \
     # Cleanup

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
     wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
     apt-get update && \
-    apt-get install google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 -y --no-install-recommends && \
+    apt-get install google-chrome-stable -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     # Node.js and Yarn v1.x
     mkdir -p /etc/apt/keyrings && \


### PR DESCRIPTION
## Link to Jira Ticket (if applicable)

n/a

## Description

The NodeSource installation script [has been deprecated](https://github.com/nodesource/distributions#new-update-%EF%B8%8F), which means pdf-libs and pdf-server no longer receive up-to-date versions of NodeJS. This PR updates the NodeJS installation instructions to conform to the [new installation instructions](https://github.com/nodesource/distributions#installation-instructions).

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
