### PR TITLE
add debug dependency'

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.5",
+    "debug": "^4.3.4",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "formidable": "^1.2.2",


### PR DESCRIPTION
There was something wrong with the pdf-libs:2.1.1 image, namely that the debug module was not being installed. Upon further investigation, it seems that the dependency was present in development environments but never added to the package.json file even though it was a runtime dependency. Development environments might enjoy the library due to it being a nested dependency, but calls to `yarn --production` will omit the dependency and throw a runtime error when customers try to run the pdf-server.