### PR TITLE
FIO-8733: Update Docker build process

### DIFF
--- a/cpp/extract-formfields/CMakeLists.txt
+++ b/cpp/extract-formfields/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 set (CMAKE_CXX_STANDARD 17)
-
+option(STATIC "Build static binary" ON)
 project(extract-formfields)
 
 find_library(poppler poppler)

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04 AS builder
 LABEL maintainer="Form.io <support@form.io>"
 
 # Set initial environment variables
@@ -7,43 +7,18 @@ ENV PDF2HTMLEX_URL=https://github.com/pdf2htmlEX/pdf2htmlEX/releases/download/v0
     DEBIAN_FRONTEND=noninteractive \
     NODE_MAJOR=20
 
-# Install dependencies, fonts, chromium, and pdf2htmlEX
+# install pdf2htmlEX and NodeJS
 RUN apt-get update && \
     apt-get upgrade -y && \
     # Dependencies
     apt-get install -y \
-    gnupg \
     wget \
-    curl \
-    ca-certificates \
-    g++ \
-    cmake \
-    make \
-    openssh-client \
     git \
-    libcap2-bin \
-    libpoppler-dev \
-    libpoppler-qt5-dev \
-    qtbase5-dev \
-    poppler-utils \
-    ghostscript && \
+    gpg \
+    curl && \
     # pdf2htmlEX
     wget "$PDF2HTMLEX_URL" && \
     apt-get install -y --no-install-recommends ./$PDF2HTMLEX && \
-    # Disable EULA agreement for msttcorefonts
-    echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections && \
-    # Fonts
-    apt-get install -y ttf-mscorefonts-installer && \
-    wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz && \
-    tar -xf gf.tar.gz && \
-    mkdir -p /usr/share/fonts/truetype/google-fonts && \
-    find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 && \
-    # Chromium
-    wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
-    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
-    apt-get update && \
-    apt-get install google-chrome-stable -y --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/* && \
     # Node.js and Yarn v1.x
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
@@ -51,7 +26,56 @@ RUN apt-get update && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
-    npm install -g yarn && \
+    npm install -g yarn
+
+WORKDIR /usr/src/pdf-libs
+# Install node.js packages
+COPY package.json ./
+COPY yarn.lock ./
+RUN yarn install --production --frozen-lockfile
+
+# Add sources
+COPY src ./src
+COPY *.js ./
+
+# Add docs
+COPY docs ./docs
+
+FROM node:20-bookworm-slim
+LABEL maintainer="Form.io <support@form.io>"
+
+# Update sources, install dependencies, and install fonts
+RUN echo "deb http://deb.debian.org/debian/ bookworm main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://deb.debian.org/debian/ bookworm main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian/ bookworm-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://deb.debian.org/debian/ bookworm-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get upgrade && \
+    # Disable EULA agreement for msttcorefonts
+    echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections && \
+    # Dependencies
+    apt-get install -y --no-install-recommends \
+    wget \
+    g++ \
+    cmake \
+    make \
+    ca-certificates \
+    libpoppler-dev \
+    libpoppler-qt5-dev \
+    qtbase5-dev \
+    poppler-utils \
+    ghostscript && \
+    # libjpeg8 dependency for pdf2htmlEX (libjpeg62-turbo is not available in bookworm)
+    wget https://archive.debian.org/debian/pool/main/libj/libjpeg8/libjpeg8_8b-1_amd64.deb && \
+    apt-get install -y ./libjpeg8_8b-1_amd64.deb && \
+    # Fonts
+    wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz && \
+    tar -xf gf.tar.gz && \
+    mkdir -p /usr/share/fonts/truetype/google-fonts && \
+    find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 && \
+    rm -f /etc/apt/sources.list && \
     # Cleanup
     apt-get clean && \
     rm -f gf.tar.gz && \
@@ -65,25 +89,15 @@ COPY cpp ./cpp
 ARG EXTRACT_FORMFIELDS_ROOT=$APP_ROOT/cpp/extract-formfields
 WORKDIR $EXTRACT_FORMFIELDS_ROOT
 RUN ${EXTRACT_FORMFIELDS_ROOT}/build.sh
+WORKDIR $APP_ROOT
 
 # Set runtime environment variables
 ENV EXTRACT_FORMFIELDS=$EXTRACT_FORMFIELDS_ROOT/bin/extract-formfields \
     PDF2HTMLEX_PATH="/usr/local/bin/pdf2htmlEX" \
     PSTOPDF_PATH="/usr/bin/ps2pdf"
 
-WORKDIR $APP_ROOT
-
-# Installing node.js packages
-COPY package.json ./
-COPY yarn.lock ./
-RUN yarn install --production
-
-# Adding sources
-COPY src ./src
-COPY *.js ./
-
-# Adding docs
-COPY docs ./docs
+COPY --from=builder ${PDF2HTMLEX_PATH} ${PDF2HTMLEX_PATH}
+COPY --from=builder /usr/src/pdf-libs /usr/src/pdf-libs
 
 EXPOSE ${PORT}
 


### PR DESCRIPTION
## Link to Jira Ticket (if applicable)

https://formio.atlassian.net/browse/FIO-8733

## Description

In an attempt to reduce the number of CVEs detected by Amazon Inspector, we've changed the base image from Ubuntu 24.04 to debian bookworm (12) slim. This means that:

* pdf2htmlEX still has to be compiled in Ubuntu and moved over
* some pdf2htmlEX dependencies must be cobbled together in the main image
* I've gone ahead and removed the chromium install, as pdf-libs has no need for it

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
