### PR TITLE
FIO-9177: update dockerfile to build pdf2htmlex from source

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,50 +1,8 @@
-FROM ubuntu:24.04 AS builder
-LABEL maintainer="Form.io <support@form.io>"
-
-# Set initial environment variables
-ENV PDF2HTMLEX_URL=https://github.com/pdf2htmlEX/pdf2htmlEX/releases/download/v0.18.8.rc1/pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
-    PDF2HTMLEX=pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
-    DEBIAN_FRONTEND=noninteractive \
-    NODE_MAJOR=20
-
-# install pdf2htmlEX and NodeJS
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    # Dependencies
-    apt-get install -y \
-    wget \
-    git \
-    gpg \
-    curl && \
-    # pdf2htmlEX
-    wget "$PDF2HTMLEX_URL" && \
-    apt-get install -y --no-install-recommends ./$PDF2HTMLEX && \
-    # Node.js and Yarn v1.x
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs && \
-    npm install -g yarn
-
-WORKDIR /usr/src/pdf-libs
-# Install node.js packages
-COPY package.json ./
-COPY yarn.lock ./
-RUN yarn install --production --frozen-lockfile
-
-# Add sources
-COPY src ./src
-COPY *.js ./
-
-COPY test ./test
-
-# Add docs
-COPY docs ./docs
-
 FROM node:20-bookworm-slim
 LABEL maintainer="Form.io <support@form.io>"
+
+# Set installation environment variables
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Update sources, install dependencies, and install fonts
 RUN echo "deb http://deb.debian.org/debian/ bookworm main contrib non-free" > /etc/apt/sources.list && \
@@ -68,20 +26,42 @@ RUN echo "deb http://deb.debian.org/debian/ bookworm main contrib non-free" > /e
     libpoppler-qt5-dev \
     qtbase5-dev \
     poppler-utils \
-    ghostscript && \
-    # libjpeg8 dependency for pdf2htmlEX (libjpeg62-turbo is not available in bookworm)
-    wget https://archive.debian.org/debian/pool/main/libj/libjpeg8/libjpeg8_8b-1_amd64.deb && \
-    apt-get install -y ./libjpeg8_8b-1_amd64.deb && \
+    ghostscript \
+    git \
+    sudo && \
     # Fonts
     wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz && \
     tar -xf gf.tar.gz && \
     mkdir -p /usr/share/fonts/truetype/google-fonts && \
-    find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 && \
-    rm -f /etc/apt/sources.list && \
-    # Cleanup
-    apt-get clean && \
-    rm -f gf.tar.gz && \
-    rm -rf /fonts-main
+    find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1
+
+# Install pdf2htmlEX
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && git clone --single-branch https://github.com/pdf2htmlEX/pdf2htmlEX.git \
+    && cd pdf2htmlEX \
+    # openjdk-8-jre-headless is not available in bookworm, so we remove it from the script
+    # (it seems like we don't actually need it to build successfully)
+    && sed -i '/openjdk-8-jre-headless/d' ./buildScripts/getBuildToolsApt \
+    && ./buildScripts/buildInstallLocallyApt \
+    && cd .. \
+    && rm -rf pdf2htmlEX
+
+WORKDIR /usr/src/pdf-libs
+
+# Install pdf-libs npm dependencies
+COPY package.json ./
+COPY yarn.lock ./
+RUN yarn install --production --frozen-lockfile
+
+# Add sources
+COPY src ./src
+COPY *.js ./
+
+COPY test ./test
+
+# Add docs
+COPY docs ./docs
 
 ENV APP_ROOT=/usr/src/pdf-libs
 WORKDIR $APP_ROOT
@@ -98,8 +78,14 @@ ENV EXTRACT_FORMFIELDS=$EXTRACT_FORMFIELDS_ROOT/bin/extract-formfields \
     PDF2HTMLEX_PATH="/usr/local/bin/pdf2htmlEX" \
     PSTOPDF_PATH="/usr/bin/ps2pdf"
 
-COPY --from=builder ${PDF2HTMLEX_PATH} ${PDF2HTMLEX_PATH}
-COPY --from=builder /usr/src/pdf-libs /usr/src/pdf-libs
+# Clean up
+RUN rm -f /etc/apt/sources.list && \
+    apt-get clean && \
+    rm -f gf.tar.gz && \
+    rm -rf /fonts-main && \
+    apt-get autoremove -y && \
+    apt-get remove wget -y && \
+    apt-get remove git -y
 
 EXPOSE ${PORT}
 


### PR DESCRIPTION
## Link to Jira Ticket (if applicable)

https://formio.atlassian.net/browse/FIO-9177

## Description

Certain Cypress tests were failing around PDF generation, which run on Ubuntu 24.04 runner VMs. An examination of the logs determined that those PDFs were causing pdf2htmlEX runtime errors. 

Previously, we used a pre-packaged `.deb` file to install the pdf2htmlEX binary in an Docker Ubuntu builder container, and then copied it over to a Debian container for the final pdf-libs image. Although I was never able to 100% verify that this was the cause of the pdf2htmlEX runtime errors, building the binary from source in the Debian container seems to eliminate the runtime errors. This PR eliminates the multi-stage build for pdf-libs, instead cloning the pdf2htmlEX source code and building directly into the Debian Docker image.

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
