### PR TITLE
Fix HTML Generation Timeout Parsing and Add PDFLIBS_PORT to Configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@ PDF2HTMLEX_PATH=/path/to/pdf2htmlex
 PSTOPDF_PATH=/path/to/ps2pdf
 EXTRACT_FORMFIELDS=/path/to/extract-formfields # available via cpp directory
 HIDE_FORMFIELDS=/path/to/hide-formfields # available via cpp directory
-PORT=8000
+PDFLIBS_PORT=8000
 HTML_GENERATION_TIMEOUT=7000
 HTML_GENERATION_BACKOFF=23000

--- a/config.js
+++ b/config.js
@@ -33,8 +33,8 @@ const hideFormfieldsPath = process.env.HIDE_FORMFIELDS;
 // that don't need postscript optimization to be optimized in this way, but we also want to
 // stay under common reverse proxy timeout configurations so we don't receive a 504
 const htmlGenerationTimeoutConfig = {
-  timeout: process.env.HTML_GENERATION_TIMEOUT ?? 7000,
-  backoff: process.env.HTML_GENERATION_BACKOFF ?? 23000
+  timeout: parseInt(process.env.HTML_GENERATION_TIMEOUT, 10) || 7000,
+  backoff: parseInt(process.env.HTML_GENERATION_BACKOFF, 10) || 23000
 };
 
 module.exports = {

--- a/cpp/hide-formfields/CMakeLists.txt
+++ b/cpp/hide-formfields/CMakeLists.txt
@@ -1,26 +1,22 @@
 cmake_minimum_required(VERSION 3.10)
 
-set (CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
 
 project(hide-formfields)
 
-find_library(poppler poppler)
-find_library(poppler-qt poppler-qt5)
-find_library(qt Qt5Core)
+find_package(Qt5Core REQUIRED)
+find_library(poppler_LIB poppler)
+find_library(poppler_qt_LIB poppler-qt5)
 
-message("${qt}")
-message("${poppler}")
-message("${poppler-qt}")
-
-set(LIB_DIR /lib/x86_64-linux-gnu)
+message("Qt5Core found at: ${Qt5Core_LIBRARIES}")
+message("Poppler found at: ${poppler_LIB}")
+message("Poppler-Qt5 found at: ${poppler_qt_LIB}")
 
 set(INCLUDE_POPPLER /usr/include/poppler/cpp)
 set(INCLUDE_POPPLER_QT /usr/include/poppler/qt5)
-set(INCLUDE_QT /usr/include/qt5)
-set(INCLUDE_QT_CORE /usr/include/QtCore)
+
+include_directories(${INCLUDE_POPPLER} ${INCLUDE_POPPLER_QT})
 
 add_executable(hide-formfields main.cpp)
 
-include_directories(${INCLUDE_POPPLER} ${INCLUDE_POPPLER_QT} ${INCLUDE_QT} ${INCLUDE_QT_CORE} include)
-
-target_link_libraries(hide-formfields ${qt} ${poppler} ${poppler-qt})
+target_link_libraries(hide-formfields Qt5::Core ${poppler_LIB} ${poppler_qt_LIB})


### PR DESCRIPTION
## Description

**What changed?**

*Previously, the `pdf-libs` repository handled HTML generation timeout values as strings, which sometimes caused execution issues when these values were expected to be integers. This PR ensures these timeout values (`HTML_GENERATION_TIMEOUT` and `HTML_GENERATION_BACKOFF`) are parsed as integers, preventing potential errors. Additionally, there was an inconsistency in the environment variable used for setting the server port. The code references `PDFLIBS_PORT` as the correct variable, but `.env.example` mistakenly included `PORT` instead. This PR updates `.env.example` to use `PDFLIBS_PORT`, ensuring users set the correct variable for configuring the server port.*

**Why have you chosen this solution?**

*There were multiple approaches, such as setting defaults directly in the code or casting the values each time they were used. However, parsing these values once when loading configurations proved to be the most efficient, reducing potential errors and making the configurations clear and maintainable. Correcting the environment variable to `PDFLIBS_PORT` eliminates confusion and ensures the intended behavior without falling back to a default port.*

## Dependencies

*This PR has no dependencies on other Form.io modules.*

## How has this PR been tested?

*I manually tested this PR by configuring different timeout values in `.env` to ensure they were correctly interpreted as integers. Additionally, I confirmed that specifying `PDFLIBS_PORT` in `.env` correctly sets the server port. No automated tests were required as these changes impact configuration handling only.*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above