### PR TITLE
FIO-9521: Prune non-runtime dependencies from docker image

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -17,16 +17,16 @@ jobs:
     - name: Login to Dockerhub
       run: echo ${{secrets.DOCKERHUB_ACCESS_TOKEN}} | docker login -u ${{vars.DOCKERHUB_USERNAME}} --password-stdin
 
-    - name: Build intermediate Docker image
-      run: docker build -f deployment/docker/Dockerfile -t formio/pdf-libs:tmp .
+    - name: Build production Docker image
+      run: docker build -f deployment/docker/Dockerfile -t formio/pdf-libs:${{github.ref_name}} .
 
-    - name: Run tests on the Docker image
+    - name: Build temp Docker image for testing (based off production image)
+      run: docker build -f deployment/docker/Dockerfile-with-tests -t formio/pdf-libs:tmp --build-arg REF_NAME=${{github.ref_name}} .
+    
+    - name: Run tests on the temp image
       run: docker run formio/pdf-libs:tmp npm test
 
-    - name: Build the Docker image
-      run: docker build -f deployment/docker/Dockerfile-no-tests -t formio/pdf-libs:${{github.ref_name}} .
-
-    - name: Push the Docker image
+    - name: Push the production image
       run: docker push formio/pdf-libs:${{github.ref_name}}
     
     - name: Push latest

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -71,8 +71,10 @@ ARG EXTRACT_FORMFIELDS_ROOT=$APP_ROOT/cpp/extract-formfields
 
 RUN apt update && apt upgrade -y && \
     apt install -y \
-    qtbase5-dev \
-    libpoppler-qt5-dev \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5xml5 \
+    libpoppler-qt5-1 \
     poppler-utils \
     ghostscript \
     && rm -f /etc/apt/sources.list \

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -89,8 +89,6 @@ RUN yarn install --production --frozen-lockfile
 COPY src ./src
 COPY *.js ./
 
-COPY test ./test
-
 # Add docs
 COPY docs ./docs
 

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -33,7 +33,8 @@ RUN echo "deb http://deb.debian.org/debian/ bookworm main contrib non-free" > /e
     && wget https://github.com/google/fonts/archive/main.tar.gz -O gf.tar.gz \
     && tar -xf gf.tar.gz \
     && mkdir -p /usr/share/fonts/truetype/google-fonts \
-    && find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1
+    && find ./fonts-main/ -name "*.ttf" -exec install -m644 {} /usr/share/fonts/truetype/google-fonts/ \; || return 1 \
+    && rm gf.tar.gz && rm -rf fonts-main
 
 # Install pdf2htmlEX
 RUN apt-get update \
@@ -54,10 +55,12 @@ ENV APP_ROOT=/usr/src/pdf-libs
 ARG EXTRACT_FORMFIELDS_ROOT=$APP_ROOT/cpp/extract-formfields
 
 WORKDIR $APP_ROOT
-
-COPY cpp ./cpp
+# only copy extract-formfields since hide-formfields is broken
+COPY cpp/extract-formfields $EXTRACT_FORMFIELDS_ROOT
 WORKDIR $EXTRACT_FORMFIELDS_ROOT
-RUN $EXTRACT_FORMFIELDS_ROOT/build.sh
+RUN $EXTRACT_FORMFIELDS_ROOT/build.sh && \
+    # only preserve the executable
+    find . -mindepth 1 -maxdepth 1 ! -name 'bin' -exec rm -rf {} +
 
 # ---------------------------------------------
 
@@ -71,7 +74,10 @@ RUN apt update && apt upgrade -y && \
     qtbase5-dev \
     libpoppler-qt5-dev \
     poppler-utils \
-    ghostscript
+    ghostscript \
+    && rm -f /etc/apt/sources.list \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* 
 
 WORKDIR $APP_ROOT
 
@@ -81,9 +87,9 @@ COPY --from=builder ${APP_ROOT}/cpp ./cpp
 COPY --from=builder /usr/local/bin/pdf2htmlEX /usr/local/bin/pdf2htmlEX
 
 # Install pdf-libs npm dependencies
-COPY package.json ./
-COPY yarn.lock ./
-RUN yarn install --production --frozen-lockfile
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile \
+    && yarn cache clean
 
 # Add sources
 COPY src ./src
@@ -96,9 +102,6 @@ COPY docs ./docs
 ENV EXTRACT_FORMFIELDS=$EXTRACT_FORMFIELDS_ROOT/bin/extract-formfields \
     PDF2HTMLEX_PATH="/usr/local/bin/pdf2htmlEX" \
     PSTOPDF_PATH="/usr/bin/ps2pdf"
-
-# Clean up
-RUN rm -f /etc/apt/sources.list apt-get clean
 
 EXPOSE ${PORT}
 

--- a/deployment/docker/Dockerfile-no-tests
+++ b/deployment/docker/Dockerfile-no-tests
@@ -1,5 +1,0 @@
-FROM formio/pdf-libs:tmp
-
-WORKDIR /usr/src/pdf-libs
-# Remove test folder
-RUN rm -rf test

--- a/deployment/docker/Dockerfile-with-tests
+++ b/deployment/docker/Dockerfile-with-tests
@@ -1,0 +1,8 @@
+FROM formio/pdf-libs:${REF_NAME}
+
+WORKDIR /usr/src/pdf-libs
+
+# run again without --production flag to install dev dependencies
+RUN yarn install --frozen-lockfile
+
+COPY test ./test

--- a/package.json
+++ b/package.json
@@ -13,24 +13,24 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "assert": "^2.1.0",
     "cors": "^2.8.5",
     "debug": "^4.3.6",
     "dotenv": "^16.4.7",
-    "eslint-plugin-mocha": "^10.5.0",
     "express": "^4.21.2",
     "formidable": "^3.5.2",
     "fs-extra": "^11.2.0",
     "lodash": "^4.17.21",
-    "mocha": "^10.8.1",
-    "superagent": "^10.1.1",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "assert": "^2.1.0",
     "eslint": "^9.6.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-formio": "^1.1.4",
     "eslint-plugin-import": "^2.29.1",
-    "nodemon": "^3.1.4"
+    "eslint-plugin-mocha": "^10.5.0",
+    "mocha": "^10.8.1",
+    "nodemon": "^3.1.4",
+    "superagent": "^10.1.1"
   }
 }


### PR DESCRIPTION
## Link to Jira Ticket (if applicable)

https://formio.atlassian.net/browse/FIO-9521

## Description

**What changed?**

- Updated docker workflow to:
  1. First build prod image
  2. Base test (tmp) image off prod
  3. Run tests on tmp image
  4. Push prod image if tests pass
  (previously, the testing image extended the prod image, so the prod image had to have the tests and node dev dependencies)

- Replaced `qtbase5-dev` and `libpoppler-qt5-dev`, which contain build dependencies as well as runtime dependencies with only the runtime dependencies needed by `extract-formfields` (`pdf2htmlEX` doesn't relate to these libraries). I determined which dynamic/runtime dependencies were needed by running `ldd` on the executables. I
  
 Dynamic/runtime deps are identical before and after my changes (`extract-formfields` executable).
<img width="1278" alt="Screenshot 2025-02-18 at 12 49 17 PM" src="https://github.com/user-attachments/assets/bde14927-5a1a-4717-bd8e-2fe76c2b6f47" />


Identical deps before and after (for `pdf2htmlEX`).
<img width="1214" alt="Screenshot 2025-02-18 at 12 51 36 PM" src="https://github.com/user-attachments/assets/56be1e05-ce0c-4808-bd40-40750a356596" />


- Removed tests and node dev dependencies from prod image. 
- Removed build files related to extract-formfields from prod image, leaving only the executable. 
- Removed hide-formfields build files since it wasn't being built in the dockerfile and since [it looks like it is broken](https://github.com/formio/pdf-libs/commit/b1e4aac967e5d0bdc2eb519c5874c94282a5c7e7).
- Removed apt and yarn caches from prod image


**Why have you chosen this solution?**

To reduce the size of the image and remove dependencies not needed at runtime. 

## Dependencies

n/a

## How has this PR been tested?

`extract-formfileds` functionality tested manually via local API portal PDF upload and via the upload script found in my branch [here](https://github.com/formio/scripts/tree/expand-pdf-tests/pdf-load-tests) in the script repo.

`pdf2htmlEX` functionality tested manually by viewing pdf as `.html` file via the API server url. i.e. 
<img width="1242" alt="Screenshot 2025-02-18 at 12 57 15 PM" src="https://github.com/user-attachments/assets/ae7f87dd-64f8-4101-ac3f-181a48b8c038" />


## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
